### PR TITLE
Add a modal for unnamed seeds

### DIFF
--- a/KH3Randomizer/Components/Common/UnnamedSeedModal.razor
+++ b/KH3Randomizer/Components/Common/UnnamedSeedModal.razor
@@ -10,7 +10,6 @@
     <button @onclick="ModalInstance.CancelAsync" class="btn kh-button" style="margin-left: 15px;">Go Back</button>
     <button @onclick="CloseModal" class="btn kh-button-cancel" style="margin-left: 15px;">Continue Without a Seed Name</button>
 
-
 </div>
 
 @code {

--- a/KH3Randomizer/Components/Common/UnnamedSeedModal.razor
+++ b/KH3Randomizer/Components/Common/UnnamedSeedModal.razor
@@ -1,0 +1,24 @@
+﻿<div class="simple-form redirect-modal" style="min-width: 60vw; background-color: #F2F2F2;">
+    <p>
+        You did not enter a name for your seed! The seed name is what is used to randomize items, and without a seed name nothing would be randomized.
+        If you wish to go back and enter a seed name, please either click the Go Back button on the bottom left or close this modal.
+    </p>
+    <p>
+        Otherwise, if you intended to leave your seed name blank, feel free to continue.
+    </p>
+
+    <button @onclick="ModalInstance.CancelAsync" class="btn kh-button" style="margin-left: 15px;">Go Back</button>
+    <button @onclick="CloseModal" class="btn kh-button-cancel" style="margin-left: 15px;">Continue Without a Seed Name</button>
+
+
+</div>
+
+@code {
+
+    [CascadingParameter] BlazoredModalInstance ModalInstance { get; set; }
+
+    private void CloseModal()
+    {
+        ModalInstance.CloseAsync(ModalResult.Ok($"User closed modal"));
+    }
+}

--- a/KH3Randomizer/Components/Common/UnnamedSeedModal.razor.css
+++ b/KH3Randomizer/Components/Common/UnnamedSeedModal.razor.css
@@ -1,0 +1,36 @@
+.redirect-modal {
+    max-height: 80vh;
+    max-width: 50vw;
+    min-width: 80vw;
+    overflow-y: auto;
+    background-color: #F2F2F2;
+}
+
+.kh-button {
+    background: linear-gradient(to right, #015eea, #00c0fa);
+    padding: 5px 25px;
+    border-radius: 10px;
+    color: white;
+    border: unset;
+    opacity: 1;
+    transition: opacity 0.3s ease-in-out;
+    margin: 5px;
+}
+
+    .kh-button:hover {
+        opacity: .75;
+    }
+
+.kh-button-cancel {
+    background-color: transparent;
+    padding: 5px 25px;
+    border-radius: 10px;
+    color: black;
+    border: grey solid 1px;
+    opacity: 1;
+    transition: opacity 0.3s ease-in-out;
+}
+
+    .kh-button-cancel:hover {
+        opacity: .75;
+    }

--- a/KH3Randomizer/Components/Pools.razor
+++ b/KH3Randomizer/Components/Pools.razor
@@ -173,11 +173,13 @@
 
     <label style="margin-left: 10px;"><i>This feature is active but not supported for the 1.1 release.</i></label>
     
-    <button class="btn kh-button" onclick="@ContinueTo" style="float: right;">Continue to @(this.IsPlando ? "Options" : "Quality of Life")...</button>
+    <button class="btn kh-button" @onclick="@(() => { string section = this.IsPlando ? "Options" : "Quality of Life"; this.ContinueToNext(section); })" style="float: right;">Continue to @(this.IsPlando ? "Options" : "Quality of Life")...</button>
     }
 </div>
 
 @code {
+    [CascadingParameter] public IModalService Modal { get; set; }
+
     [Parameter] public EventCallback<string> ContinueTo { get; set; }
     [Parameter] public EventCallback<Dictionary<string, RandomizeOptionEnum>> UpdateAvailablePools { get; set; }
     [Parameter] public EventCallback<bool> UpdatePlando { get; set; }
@@ -286,5 +288,26 @@
         var randomizedItems = this.RandomizerService.Process(this.currentSeed, combinedDictionary, this.exceptions, this.CanBeNone);
 
         this.UpdateRandomizedOptions.InvokeAsync(randomizedItems);
+    }
+
+    private async void ContinueToNext(string section)
+    {
+        if (string.IsNullOrEmpty(this.CurrentSeed))
+        {
+            var parameters = new ModalParameters();
+            var options = new ModalOptions { Class = "modal-custom" };
+
+            var unnamedSeedModal = Modal.Show<UnnamedSeedModal>("Unnamed Seed", parameters, options);
+            var result = await unnamedSeedModal.Result;
+
+            if (!result.Cancelled && result.Data != null && (string)result.Data == "User closed modal")
+            {
+                await this.ContinueTo.InvokeAsync(section);
+            }
+        }
+        else
+        {
+            await this.ContinueTo.InvokeAsync(section);
+        }
     }
 }

--- a/KH3Randomizer/Components/Pools.razor
+++ b/KH3Randomizer/Components/Pools.razor
@@ -300,14 +300,12 @@
             var unnamedSeedModal = Modal.Show<UnnamedSeedModal>("Unnamed Seed", parameters, options);
             var result = await unnamedSeedModal.Result;
 
-            if (!result.Cancelled && result.Data != null && (string)result.Data == "User closed modal")
+            if (result.Cancelled || result.Data == null || (string)result.Data != "User closed modal")
             {
-                await this.ContinueTo.InvokeAsync(section);
+                return;
             }
         }
-        else
-        {
-            await this.ContinueTo.InvokeAsync(section);
-        }
+        
+        await this.ContinueTo.InvokeAsync(section);
     }
 }


### PR DESCRIPTION
Adds a modal on the Pools page if a user tries to continue without entering a seed name. This seems like an issue a lot of people might be running into that's causing seeds to not be randomized, so having a warning would be nice.